### PR TITLE
New platforms to base height off of grass position

### DIFF
--- a/foreground.js
+++ b/foreground.js
@@ -14,6 +14,28 @@ function game(){
   noStroke();
   fill(100, 200, 75);
   rect(width/2, height-(grassHeight/2), width, grassHeight);
+
+  // Wall
+  noStroke();
+  fill(0)
+  rect(1100, height - (grassHeight * 1.62), 10, height/3)
+
+  // Platforms
+  stroke(0);
+  strokeWeight(3)
+  fill(231, 149, 72)
+  rect(950, height - (grassHeight * 2), 130, 10)
+
+  stroke(0);
+  strokeWeight(3);
+  fill(231, 149, 72);
+  rect(750, height - (grassHeight * 1.6), 130, 10)
+
+  stroke(0);
+  strokeWeight(3);
+  fill(231, 149, 72);
+  rect(525, height - (grassHeight * 1.2), 130, 10)
+
   // Window frame
   noFill();
   stroke(0);


### PR DESCRIPTION
I remade the wall and platforms to make their heights based off of the positioning of the grass. The rest of the properties of the platforms I used hard coded values since I think each level will have different sized platforms. Let me know if I should use variable values instead of hard coded ones for the other rectangle parameters.